### PR TITLE
New node extraction logic for thermostats

### DIFF
--- a/custom_components/jg_aura/__init__.py
+++ b/custom_components/jg_aura/__init__.py
@@ -7,16 +7,17 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.discovery import load_platform
 
 DOMAIN = "jg_aura"
-CONF_EMAIL = "email"
-CONF_PASSWORD = "password"
-CONF_HOST = "host"
+CONF_REFRESH_RATE = "refresh_rate"
+CONF_ENABLE_HOT_WATER = "hot_water"
 
 CONFIG_SCHEMA = vol.Schema(
 	{
 		DOMAIN: vol.Schema({
 			vol.Required(CONF_HOST): cv.string,
 			vol.Required(CONF_EMAIL): cv.string,
-			vol.Required(CONF_PASSWORD): cv.string
+			vol.Required(CONF_PASSWORD): cv.string,
+			vol.Optional(CONF_ENABLE_HOT_WATER, default=True): cv.boolean,
+			vol.Optional(CONF_REFRESH_RATE, default=30) : cv.positive_int
 		})
 	},
 	extra = vol.ALLOW_EXTRA
@@ -26,11 +27,15 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 	load_platform(hass, 'climate', DOMAIN, {
 		CONF_HOST: config[DOMAIN][CONF_HOST],
 		CONF_EMAIL: config[DOMAIN][CONF_EMAIL],
-		CONF_PASSWORD: config[DOMAIN][CONF_PASSWORD]
+		CONF_PASSWORD: config[DOMAIN][CONF_PASSWORD],
+		CONF_REFRESH_RATE: config[DOMAIN][CONF_REFRESH_RATE]
 	}, config)
-	load_platform(hass, 'switch', DOMAIN, {
-		CONF_HOST: config[DOMAIN][CONF_HOST],
-		CONF_EMAIL: config[DOMAIN][CONF_EMAIL],
-		CONF_PASSWORD: config[DOMAIN][CONF_PASSWORD]
-	}, config)
+
+	if config[DOMAIN][CONF_ENABLE_HOT_WATER]:
+		load_platform(hass, 'switch', DOMAIN, {
+			CONF_HOST: config[DOMAIN][CONF_HOST],
+			CONF_EMAIL: config[DOMAIN][CONF_EMAIL],
+			CONF_PASSWORD: config[DOMAIN][CONF_PASSWORD]
+		}, config)
+
 	return True

--- a/custom_components/jg_aura/climate.py
+++ b/custom_components/jg_aura/climate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_HOST
+from . import CONF_REFRESH_RATE
 from . import jg_client
 from . import thermostat
 from datetime import timedelta
@@ -42,7 +43,7 @@ async def async_setup_platform(
 	host = discovery_info[CONF_HOST]
 	email = discovery_info[CONF_EMAIL]
 	password = discovery_info[CONF_PASSWORD]
-	
+
 	thermostatEntities = []
 	client = jg_client.JGClient(host, email, password)
 
@@ -66,7 +67,7 @@ async def async_setup_platform(
 		_LOGGER,
 		name = "climate",
 		update_method = async_update_data,
-		update_interval = timedelta(seconds = 2)
+		update_interval = timedelta(seconds = discovery_info[CONF_REFRESH_RATE])
 	)
 
 	coordinator.async_add_listener(update_entities)
@@ -147,10 +148,9 @@ class JGAuraThermostat(CoordinatorEntity, ClimateEntity):
 	def preset_mode(self):
 		return self._preset_mode
 
-
 	@property
 	def preset_modes(self):
-		return ["High", "Low", "Away"]
+		return jg_client.RUN_MODES
 	
 	@property
 	def supported_features(self):
@@ -162,7 +162,7 @@ class JGAuraThermostat(CoordinatorEntity, ClimateEntity):
 			return
 
 		self._target_temp = temperature
-		await self._client.SetThermostatTemprature(self._id, temperature)
+		await self._client.SetThermostatTemperature(self._id, temperature)
 
 	async def async_set_preset_mode(self, preset_mode):
 		self._preset_mode = preset_mode


### PR DESCRIPTION
Fixes #1 

A couple of different things were done here:

* Add a parameter to control the the thermostats' refresh rate (defaults to 30 seconds) [`refresh_rate`]
* Add a parameter to enable the thermostats' optional 'hot water' feature (defaults to true) [`hot_water`]
* Support all the 'Run Modes' of the thermostat
* Change node reading algorithm to
    * Use the `names` instead of the `id`.
    * Support >10 thermostats
    * (Albeit with poor Python) reduce the amount of work in the `refresh` loop by filtering first the interesting nodes, instead of going through all of them multiple times. 